### PR TITLE
lock requirement modules version for splatnet2statink

### DIFF
--- a/src/app/splatoon/Dockerfile
+++ b/src/app/splatoon/Dockerfile
@@ -3,6 +3,7 @@ FROM resin/rpi-raspbian
 MAINTAINER sayyeah-t <@SayYeah1121>
 
 COPY splatoon /usr/bin
+COPY requirements.txt /
 
 RUN mkdir /etc/take2-chatops && \
     apt-get update && \
@@ -10,7 +11,7 @@ RUN mkdir /etc/take2-chatops && \
     mkdir -p /opt/splatnet2statink
     git clone https://github.com/frozenpandaman/splatnet2statink.git \
     /opt/splatnet2statink && \
-    pip install -r /opt/splatnet2statink/requirements.txt && \
+    pip install -r /requirements.txt && \
 
 
 CMD ["/usr/bin/splatoon"]

--- a/src/app/splatoon/requirements.txt
+++ b/src/app/splatoon/requirements.txt
@@ -1,0 +1,4 @@
+future==0.16.0
+msgpack-python==0.5.6
+requests==2.12.4
+requests-oauthlib==0.7.0


### PR DESCRIPTION
futureのversionが0.17.0だと動かなかったので他のrequirementもついでにバージョンをロック。
現状動いているノードでpip freezeした結果をrequirements.txtに記述。